### PR TITLE
fix unishare not setting samba share name for names with spaces

### DIFF
--- a/network/services/unishare/files/unishare.init
+++ b/network/services/unishare/files/unishare.init
@@ -95,7 +95,7 @@ add_samba_share() {
         cat <<-EOF
     add $1 sambashare
     set $1.@sambashare[-1].unishare=1
-    set $1.@sambashare[-1].path=$2
+    set $1.@sambashare[-1].path='$2'
     set $1.@sambashare[-1].name='$3'
     set $1.@sambashare[-1].read_only=yes
     set $1.@sambashare[-1].force_root=1


### PR DESCRIPTION
修复 unishare 添加的共享名称或路径包含空格时，无法正确设置 samba share name 问题

<img width="1516" height="1246" alt="image" src="https://github.com/user-attachments/assets/c1cc550a-12a2-443c-9a47-64b418616366" />

<img width="686" height="574" alt="image" src="https://github.com/user-attachments/assets/37abb5bc-a4b4-4d66-9dff-09b077079b16" />
